### PR TITLE
Alteração no endereço do banco de dados

### DIFF
--- a/eventex/settings.py
+++ b/eventex/settings.py
@@ -76,7 +76,7 @@ WSGI_APPLICATION = 'eventex.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
-default_dburl = 'sqlite///' + os.path.join(BASE_DIR, 'db.sqlite3')
+default_dburl = 'sqlite:///' + os.path.join(BASE_DIR, 'db.sqlite3')
 
 DATABASES = {
     'default': config('DATABASE_URL', default=default_dburl, cast=dburl)


### PR DESCRIPTION
Estava faltando o ':', e por esse motivo o dj-database-url não estava conseguindo parsear.